### PR TITLE
null-value validate and validator activation features surport for dynamic models 

### DIFF
--- a/Forge.Forms/src/Forge.Forms.Tests/BoundExpressionTests.cs
+++ b/Forge.Forms/src/Forge.Forms.Tests/BoundExpressionTests.cs
@@ -66,6 +66,8 @@ namespace Forge.Forms.Tests
 
         public IEnvironment Environment => throw new NotImplementedException();
 
+        public IReadOnlyFormDefinition ModelDefinition =>null;
+
         public object GetModelInstance()
         {
             return form.Value;

--- a/Forge.Forms/src/Forge.Forms/Annotations/NullValueValidateAction.cs
+++ b/Forge.Forms/src/Forge.Forms/Annotations/NullValueValidateAction.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Forge.Forms.Annotations
+{
+    /// <summary>
+    /// Specifies the validation action when property value is null.
+    /// This option is added because most validations require a value to validate.
+    /// This can be useful when an property is not mandatory, 
+    /// but it should be within a certain range if it is filled in.
+    /// after all, we can add another attribute with NotBeNull to ensure that it is required.
+    /// There is no need to set an option such as AlwaysFalse, etc,
+    /// because it can be done by adding validation rules
+    /// </summary>
+    public enum NullValueValidateAction
+    {
+        /// <summary>
+        /// depends on the validator 
+        /// </summary>
+        Default,
+        /// <summary>
+        /// stop the validation and return true. 
+        /// </summary>
+        AlwaysTrue
+    }
+}

--- a/Forge.Forms/src/Forge.Forms/Annotations/ValueAttribute.cs
+++ b/Forge.Forms/src/Forge.Forms/Annotations/ValueAttribute.cs
@@ -116,5 +116,10 @@ namespace Forge.Forms.Annotations
         /// Specifies what happens when the validator is deactivated.
         /// </summary>
         public ValidationAction OnDeactivation { get; set; }
+
+        /// <summary>
+        /// Specifies the validation action when property value is null.
+        /// </summary>
+        public NullValueValidateAction NullValueValidation { get; set; }
     }
 }

--- a/Forge.Forms/src/Forge.Forms/Controls/DynamicForm.cs
+++ b/Forge.Forms/src/Forge.Forms/Controls/DynamicForm.cs
@@ -151,6 +151,8 @@ namespace Forge.Forms.Controls
             set => SetValue(ModelProperty, value);
         }
 
+        public IReadOnlyFormDefinition FormDefinition => currentDefinition;
+
         /// <summary>
         /// Gets the value of the current model instance.
         /// </summary>

--- a/Forge.Forms/src/Forge.Forms/Controls/FormResourceContext.cs
+++ b/Forge.Forms/src/Forge.Forms/Controls/FormResourceContext.cs
@@ -26,6 +26,8 @@ namespace Forge.Forms.Controls
 
         public IEnvironment Environment => Form.Environment;
 
+        public IReadOnlyFormDefinition ModelDefinition => Form?.FormDefinition;
+
         public object GetModelInstance()
         {
             return Form.Value;

--- a/Forge.Forms/src/Forge.Forms/Forge.Forms.csproj
+++ b/Forge.Forms/src/Forge.Forms/Forge.Forms.csproj
@@ -76,6 +76,7 @@
     <Compile Include="Annotations\ImageAttribute.cs" />
     <Compile Include="Annotations\Meta.cs" />
     <Compile Include="Annotations\MultiLineAttribute.cs" />
+    <Compile Include="Annotations\NullValueValidateAction.cs" />
     <Compile Include="Annotations\Placement.cs" />
     <Compile Include="Annotations\TextElementAttribute.cs" />
     <Compile Include="Annotations\DefaultFields.cs" />

--- a/Forge.Forms/src/Forge.Forms/FormBuilding/DynamicProperty.cs
+++ b/Forge.Forms/src/Forge.Forms/FormBuilding/DynamicProperty.cs
@@ -7,12 +7,13 @@ namespace Forge.Forms.FormBuilding
     public class DynamicProperty : IFormProperty
     {
         private readonly Attribute[] attributes;
-
-        public DynamicProperty(string name, Type propertyType, Attribute[] attributes)
+        private readonly IFormDefinition formDefinition;
+        public DynamicProperty(string name, Type propertyType, Attribute[] attributes, IFormDefinition formDefinition)
         {
             this.attributes = attributes;
             Name = name;
             PropertyType = propertyType;
+            this.formDefinition = formDefinition;
         }
 
         public string Name { get; }
@@ -20,6 +21,8 @@ namespace Forge.Forms.FormBuilding
         public Type PropertyType { get; }
 
         public Type DeclaringType => null;
+
+        public IReadOnlyFormDefinition DeclaringForm => formDefinition;
 
         public bool CanWrite => true;
 

--- a/Forge.Forms/src/Forge.Forms/FormBuilding/FormDefinition.cs
+++ b/Forge.Forms/src/Forge.Forms/FormBuilding/FormDefinition.cs
@@ -8,27 +8,38 @@ namespace Forge.Forms.FormBuilding
     public class FormDefinition : IFormDefinition
     {
         private bool frozen;
+        private readonly Dictionary<string, IValueProvider> resources;
+        private readonly Dictionary<string, string> metadata;
 
         public FormDefinition(Type modelType)
         {
             ModelType = modelType;
-            Resources = new Dictionary<string, IValueProvider>();
-            Metadata = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            resources = new Dictionary<string, IValueProvider>();
+            metadata = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
             Grid = new[] { 1d };
             FormRows = new List<FormRow>();
+            FormProperties = new List<IFormProperty>();
         }
 
         public List<FormRow> FormRows { get; set; }
 
         public Type ModelType { get; }
 
-        public IDictionary<string, string> Metadata { get; }
-
-        public IDictionary<string, IValueProvider> Resources { get; set; }
+        public IDictionary<string, string> Metadata => metadata;
+        public IDictionary<string, IValueProvider> Resources => resources;
 
         public double[] Grid { get; set; }
 
         IReadOnlyList<FormRow> IFormDefinition.FormRows => FormRows;
+
+        internal List<IFormProperty> FormProperties { get; }
+        
+
+        IReadOnlyCollection<IFormProperty> IReadOnlyFormDefinition.FormProperties => FormProperties;
+
+        IReadOnlyDictionary<string, IValueProvider> IReadOnlyFormDefinition.Resources => resources;
+
+        IReadOnlyDictionary<string, string> IReadOnlyFormDefinition.Metadata => metadata;
 
         public object CreateInstance(IResourceContext context)
         {

--- a/Forge.Forms/src/Forge.Forms/FormBuilding/IFormDefinition.cs
+++ b/Forge.Forms/src/Forge.Forms/FormBuilding/IFormDefinition.cs
@@ -5,14 +5,26 @@ using Forge.Forms.DynamicExpressions;
 
 namespace Forge.Forms.FormBuilding
 {
-    public interface IFormDefinition
+    /// <summary>
+    /// Define a read-only interface so that we can still
+    /// access it in read-only mode after it is built
+    /// </summary>
+    public interface IReadOnlyFormDefinition
+    {
+        IReadOnlyDictionary<string, IValueProvider> Resources { get; }
+
+        IReadOnlyDictionary<string, string> Metadata { get; }
+
+        IReadOnlyCollection<IFormProperty> FormProperties { get; }
+
+        Type ModelType { get; }
+    }
+    public interface IFormDefinition: IReadOnlyFormDefinition
     {
         IReadOnlyList<FormRow> FormRows { get; }
 
         double[] Grid { get; }
-
-        Type ModelType { get; }
-
+        
         IDictionary<string, IValueProvider> Resources { get; }
 
         IDictionary<string, string> Metadata { get; }

--- a/Forge.Forms/src/Forge.Forms/FormBuilding/IFormProperty.cs
+++ b/Forge.Forms/src/Forge.Forms/FormBuilding/IFormProperty.cs
@@ -11,6 +11,8 @@ namespace Forge.Forms.FormBuilding
 
         Type DeclaringType { get; }
 
+        IReadOnlyFormDefinition DeclaringForm { get; }
+
         bool CanWrite { get; }
 
         T GetCustomAttribute<T>() where T : Attribute;

--- a/Forge.Forms/src/Forge.Forms/FormBuilding/IResourceContext.cs
+++ b/Forge.Forms/src/Forge.Forms/FormBuilding/IResourceContext.cs
@@ -14,6 +14,11 @@ namespace Forge.Forms.FormBuilding
         IEnvironment Environment { get; }
 
         /// <summary>
+        /// Gets the <see cref="FormDefinition"> for current model
+        /// </summary>
+        IReadOnlyFormDefinition ModelDefinition { get; }
+
+        /// <summary>
         /// Gets current model instance.
         /// </summary>
         object GetModelInstance();

--- a/Forge.Forms/src/Forge.Forms/FormBuilding/PropertyInfoWrapper.cs
+++ b/Forge.Forms/src/Forge.Forms/FormBuilding/PropertyInfoWrapper.cs
@@ -7,10 +7,11 @@ namespace Forge.Forms.FormBuilding
     internal class PropertyInfoWrapper : IFormProperty
     {
         private readonly PropertyInfo property;
-
-        public PropertyInfoWrapper(PropertyInfo property)
+        private readonly IFormDefinition formDefinition;
+        public PropertyInfoWrapper(PropertyInfo property,IFormDefinition formDefinition)
         {
             this.property = property;
+            this.formDefinition = formDefinition;
         }
 
         public string Name => property.Name;
@@ -18,6 +19,7 @@ namespace Forge.Forms.FormBuilding
         public Type PropertyType => property.PropertyType;
 
         public Type DeclaringType => property.DeclaringType;
+        public IReadOnlyFormDefinition DeclaringForm => formDefinition;
 
         public bool CanWrite => property.CanWrite && property.GetSetMethod(true).IsPublic;
 

--- a/Forge.Forms/src/Forge.Forms/FormBuilding/Utilities.cs
+++ b/Forge.Forms/src/Forge.Forms/FormBuilding/Utilities.cs
@@ -478,6 +478,22 @@ namespace Forge.Forms.FormBuilding
                     attr.ArgumentUpdatedAction = (ValidationAction)Enum.Parse(typeof(ValidationAction), expr, true);
                 }
 
+                expr = child.TryGetAttribute("onActive");
+                if (expr != null)
+                {
+                    attr.OnActivation = (ValidationAction)Enum.Parse(typeof(ValidationAction), expr, true);
+                }
+
+                expr = child.TryGetAttribute("onDeactive");
+                if (expr != null)
+                {
+                    attr.OnDeactivation = (ValidationAction)Enum.Parse(typeof(ValidationAction), expr, true);
+                }
+                expr = child.TryGetAttribute("nullValueValidation");
+                if (expr != null)
+                {
+                    attr.NullValueValidation = (NullValueValidateAction)Enum.Parse(typeof(NullValueValidateAction), expr, true);
+                }               
                 validators.Add(attr);
             }
 

--- a/Forge.Forms/src/Forge.Forms/Validation/ComparisonValidator.cs
+++ b/Forge.Forms/src/Forge.Forms/Validation/ComparisonValidator.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Windows.Data;
+using Forge.Forms.Annotations;
 using Forge.Forms.DynamicExpressions;
 
 namespace Forge.Forms.Validation
@@ -8,8 +9,9 @@ namespace Forge.Forms.Validation
     {
         protected ComparisonValidator(ValidationPipe pipe, IProxy argument, IErrorStringProvider errorProvider,
             IBoolProxy isEnforced,
-            IValueConverter valueConverter, bool strictValidation, bool validatesOnTargetUpdated)
-            : base(pipe, errorProvider, isEnforced, valueConverter, strictValidation, validatesOnTargetUpdated)
+            IValueConverter valueConverter, bool strictValidation, bool validatesOnTargetUpdated,
+            NullValueValidateAction nullValueValidateAction = NullValueValidateAction.Default)
+            : base(pipe, errorProvider, isEnforced, valueConverter, strictValidation, validatesOnTargetUpdated, nullValueValidateAction)
         {
             Argument = argument ?? throw new ArgumentNullException(nameof(argument));
         }

--- a/Forge.Forms/src/Forge.Forms/Validation/EqualsValidator.cs
+++ b/Forge.Forms/src/Forge.Forms/Validation/EqualsValidator.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Globalization;
 using System.Windows.Data;
+using Forge.Forms.Annotations;
 using Forge.Forms.DynamicExpressions;
 
 namespace Forge.Forms.Validation
@@ -9,9 +10,10 @@ namespace Forge.Forms.Validation
     {
         public EqualsValidator(ValidationPipe pipe, IProxy argument, IErrorStringProvider errorProvider,
             IBoolProxy isEnforced,
-            IValueConverter valueConverter, bool strictValidation, bool validatesOnTargetUpdated)
+            IValueConverter valueConverter, bool strictValidation, bool validatesOnTargetUpdated,
+            NullValueValidateAction nullValueValidateAction = NullValueValidateAction.Default)
             : base(pipe, argument, errorProvider, isEnforced, valueConverter, strictValidation,
-                validatesOnTargetUpdated)
+                validatesOnTargetUpdated, nullValueValidateAction)
         {
         }
 

--- a/Forge.Forms/src/Forge.Forms/Validation/ExistsInValidator.cs
+++ b/Forge.Forms/src/Forge.Forms/Validation/ExistsInValidator.cs
@@ -2,6 +2,7 @@
 using System.Globalization;
 using System.Linq;
 using System.Windows.Data;
+using Forge.Forms.Annotations;
 using Forge.Forms.DynamicExpressions;
 
 namespace Forge.Forms.Validation
@@ -10,9 +11,10 @@ namespace Forge.Forms.Validation
     {
         public ExistsInValidator(ValidationPipe pipe, IProxy argument, IErrorStringProvider errorProvider,
             IBoolProxy isEnforced,
-            IValueConverter valueConverter, bool strictValidation, bool validatesOnTargetUpdated)
+            IValueConverter valueConverter, bool strictValidation, bool validatesOnTargetUpdated,
+            NullValueValidateAction nullValueValidateAction = NullValueValidateAction.Default)
             : base(pipe, argument, errorProvider, isEnforced, valueConverter, strictValidation,
-                validatesOnTargetUpdated)
+                validatesOnTargetUpdated,nullValueValidateAction)
         {
         }
 

--- a/Forge.Forms/src/Forge.Forms/Validation/FieldValidator.cs
+++ b/Forge.Forms/src/Forge.Forms/Validation/FieldValidator.cs
@@ -1,6 +1,7 @@
 ﻿using System.Globalization;
 using System.Windows.Controls;
 using System.Windows.Data;
+using Forge.Forms.Annotations;
 using Forge.Forms.DynamicExpressions;
 
 namespace Forge.Forms.Validation
@@ -8,7 +9,8 @@ namespace Forge.Forms.Validation
     public abstract class FieldValidator : ValidationRule
     {
         protected FieldValidator(ValidationPipe pipe, IErrorStringProvider errorProvider, IBoolProxy isEnforced,
-            IValueConverter valueConverter, bool strictValidation, bool validatesOnTargetUpdated)
+            IValueConverter valueConverter, bool strictValidation, bool validatesOnTargetUpdated,
+            NullValueValidateAction nullValueValidateAction = NullValueValidateAction.Default)
             : base(ValidationStep.ConvertedProposedValue, validatesOnTargetUpdated)
         {
             ValidationPipe = pipe;
@@ -16,6 +18,7 @@ namespace Forge.Forms.Validation
             ValueConverter = valueConverter;
             IsEnforced = isEnforced;
             StrictValidation = strictValidation;
+            NullValueValidation = nullValueValidateAction;
         }
 
         public IValueConverter ValueConverter { get; }
@@ -28,8 +31,16 @@ namespace Forge.Forms.Validation
 
         public bool StrictValidation { get; }
 
+        public NullValueValidateAction NullValueValidation { get; }
+
         public sealed override ValidationResult Validate(object value, CultureInfo cultureInfo)
         {
+
+            if (value == null && NullValueValidation == NullValueValidateAction.AlwaysTrue)
+            {
+                return ValidationResult.ValidResult;
+            }
+
             if (ValidationPipe != null)
             {
                 // Pass if another validator has already reported an error.

--- a/Forge.Forms/src/Forge.Forms/Validation/GreaterThanEqualValidator.cs
+++ b/Forge.Forms/src/Forge.Forms/Validation/GreaterThanEqualValidator.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Globalization;
 using System.Windows.Data;
+using Forge.Forms.Annotations;
 using Forge.Forms.DynamicExpressions;
 
 namespace Forge.Forms.Validation
@@ -9,9 +10,10 @@ namespace Forge.Forms.Validation
     {
         public GreaterThanEqualValidator(ValidationPipe pipe, IProxy argument, IErrorStringProvider errorProvider,
             IBoolProxy isEnforced,
-            IValueConverter valueConverter, bool strictValidation, bool validatesOnTargetUpdated)
+            IValueConverter valueConverter, bool strictValidation, bool validatesOnTargetUpdated,
+            NullValueValidateAction nullValueValidateAction = NullValueValidateAction.Default)
             : base(pipe, argument, errorProvider, isEnforced, valueConverter, strictValidation,
-                validatesOnTargetUpdated)
+                validatesOnTargetUpdated,nullValueValidateAction)
         {
         }
 

--- a/Forge.Forms/src/Forge.Forms/Validation/GreaterThanValidator.cs
+++ b/Forge.Forms/src/Forge.Forms/Validation/GreaterThanValidator.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Globalization;
 using System.Windows.Data;
+using Forge.Forms.Annotations;
 using Forge.Forms.DynamicExpressions;
 
 namespace Forge.Forms.Validation
@@ -9,9 +10,10 @@ namespace Forge.Forms.Validation
     {
         public GreaterThanValidator(ValidationPipe pipe, IProxy argument, IErrorStringProvider errorProvider,
             IBoolProxy isEnforced,
-            IValueConverter valueConverter, bool strictValidation, bool validatesOnTargetUpdated)
+            IValueConverter valueConverter, bool strictValidation, bool validatesOnTargetUpdated,
+            NullValueValidateAction nullValueValidateAction = NullValueValidateAction.Default)
             : base(pipe, argument, errorProvider, isEnforced, valueConverter, strictValidation,
-                validatesOnTargetUpdated)
+                validatesOnTargetUpdated,nullValueValidateAction)
         {
         }
 

--- a/Forge.Forms/src/Forge.Forms/Validation/LessThanEqualValidator.cs
+++ b/Forge.Forms/src/Forge.Forms/Validation/LessThanEqualValidator.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Globalization;
 using System.Windows.Data;
+using Forge.Forms.Annotations;
 using Forge.Forms.DynamicExpressions;
 
 namespace Forge.Forms.Validation
@@ -9,9 +10,10 @@ namespace Forge.Forms.Validation
     {
         public LessThanEqualValidator(ValidationPipe pipe, IProxy argument, IErrorStringProvider errorProvider,
             IBoolProxy isEnforced,
-            IValueConverter valueConverter, bool strictValidation, bool validatesOnTargetUpdated)
+            IValueConverter valueConverter, bool strictValidation, bool validatesOnTargetUpdated,
+            NullValueValidateAction nullValueValidateAction = NullValueValidateAction.Default)
             : base(pipe, argument, errorProvider, isEnforced, valueConverter, strictValidation,
-                validatesOnTargetUpdated)
+                validatesOnTargetUpdated,nullValueValidateAction)
         {
         }
 

--- a/Forge.Forms/src/Forge.Forms/Validation/LessThanValidator.cs
+++ b/Forge.Forms/src/Forge.Forms/Validation/LessThanValidator.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Globalization;
 using System.Windows.Data;
+using Forge.Forms.Annotations;
 using Forge.Forms.DynamicExpressions;
 
 namespace Forge.Forms.Validation
@@ -9,9 +10,10 @@ namespace Forge.Forms.Validation
     {
         public LessThanValidator(ValidationPipe pipe, IProxy argument, IErrorStringProvider errorProvider,
             IBoolProxy isEnforced,
-            IValueConverter valueConverter, bool strictValidation, bool validatesOnTargetUpdated)
+            IValueConverter valueConverter, bool strictValidation, bool validatesOnTargetUpdated,
+            NullValueValidateAction nullValueValidateAction = NullValueValidateAction.Default)
             : base(pipe, argument, errorProvider, isEnforced, valueConverter, strictValidation,
-                validatesOnTargetUpdated)
+                validatesOnTargetUpdated,nullValueValidateAction)
         {
         }
 

--- a/Forge.Forms/src/Forge.Forms/Validation/MatchPatternValidator.cs
+++ b/Forge.Forms/src/Forge.Forms/Validation/MatchPatternValidator.cs
@@ -1,6 +1,7 @@
 ﻿using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Windows.Data;
+using Forge.Forms.Annotations;
 using Forge.Forms.DynamicExpressions;
 
 namespace Forge.Forms.Validation
@@ -9,9 +10,10 @@ namespace Forge.Forms.Validation
     {
         public MatchPatternValidator(ValidationPipe pipe, IProxy argument, IErrorStringProvider errorProvider,
             IBoolProxy isEnforced,
-            IValueConverter valueConverter, bool strictValidation, bool validatesOnTargetUpdated)
+            IValueConverter valueConverter, bool strictValidation, bool validatesOnTargetUpdated,
+            NullValueValidateAction nullValueValidateAction = NullValueValidateAction.Default)
             : base(pipe, argument, errorProvider, isEnforced, valueConverter, strictValidation,
-                validatesOnTargetUpdated)
+                validatesOnTargetUpdated,nullValueValidateAction)
         {
         }
 

--- a/Forge.Forms/src/Forge.Forms/Validation/NotEqualsValidator.cs
+++ b/Forge.Forms/src/Forge.Forms/Validation/NotEqualsValidator.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Globalization;
 using System.Windows.Data;
+using Forge.Forms.Annotations;
 using Forge.Forms.DynamicExpressions;
 
 namespace Forge.Forms.Validation
@@ -9,9 +10,10 @@ namespace Forge.Forms.Validation
     {
         public NotEqualsValidator(ValidationPipe pipe, IProxy argument, IErrorStringProvider errorProvider,
             IBoolProxy isEnforced,
-            IValueConverter valueConverter, bool strictValidation, bool validatesOnTargetUpdated)
+            IValueConverter valueConverter, bool strictValidation, bool validatesOnTargetUpdated,
+            NullValueValidateAction nullValueValidateAction = NullValueValidateAction.Default)
             : base(pipe, argument, errorProvider, isEnforced, valueConverter, strictValidation,
-                validatesOnTargetUpdated)
+                validatesOnTargetUpdated,nullValueValidateAction)
         {
         }
 

--- a/Forge.Forms/src/Forge.Forms/Validation/NotExistsInValidator.cs
+++ b/Forge.Forms/src/Forge.Forms/Validation/NotExistsInValidator.cs
@@ -2,6 +2,7 @@
 using System.Globalization;
 using System.Linq;
 using System.Windows.Data;
+using Forge.Forms.Annotations;
 using Forge.Forms.DynamicExpressions;
 
 namespace Forge.Forms.Validation
@@ -10,9 +11,10 @@ namespace Forge.Forms.Validation
     {
         public NotExistsInValidator(ValidationPipe pipe, IProxy argument, IErrorStringProvider errorProvider,
             IBoolProxy isEnforced,
-            IValueConverter valueConverter, bool strictValidation, bool validatesOnTargetUpdated)
+            IValueConverter valueConverter, bool strictValidation, bool validatesOnTargetUpdated,
+            NullValueValidateAction nullValueValidateAction = NullValueValidateAction.Default)
             : base(pipe, argument, errorProvider, isEnforced, valueConverter, strictValidation,
-                validatesOnTargetUpdated)
+                validatesOnTargetUpdated,nullValueValidateAction)
         {
         }
 

--- a/Forge.Forms/src/Forge.Forms/Validation/NotMatchPatternValidator.cs
+++ b/Forge.Forms/src/Forge.Forms/Validation/NotMatchPatternValidator.cs
@@ -1,6 +1,7 @@
 ﻿using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Windows.Data;
+using Forge.Forms.Annotations;
 using Forge.Forms.DynamicExpressions;
 
 namespace Forge.Forms.Validation
@@ -9,9 +10,10 @@ namespace Forge.Forms.Validation
     {
         public NotMatchPatternValidator(ValidationPipe pipe, IProxy argument, IErrorStringProvider errorProvider,
             IBoolProxy isEnforced,
-            IValueConverter valueConverter, bool strictValidation, bool validatesOnTargetUpdated)
+            IValueConverter valueConverter, bool strictValidation, bool validatesOnTargetUpdated,
+            NullValueValidateAction nullValueValidateAction = NullValueValidateAction.Default)
             : base(pipe, argument, errorProvider, isEnforced, valueConverter, strictValidation,
-                validatesOnTargetUpdated)
+                validatesOnTargetUpdated,nullValueValidateAction)
         {
         }
 


### PR DESCRIPTION
First of all, thank you for the open source project, which has helped me a lot.
In order to use it better, I have made some modifications to some of the code. I believe these modifications are also useful to others.

1. Adding NullValueValidateAction option (which is default by the original logic) for all validator and set value when the validator is initialized. If the option is set to Always True, the validator will always return true when the field value is empty.
reason: Most existing validators (especially comparative validation) require a Non-Null value. But sometimes, when the field is not mandatory, we only want it to validate its validity when it is entered something, then the validator cannot return the expected result. ( I tried to set the validator to Non-strict, but if I did, it could not prevent form error data is entered  when submitting  )

2. Adding  support for OnActivation/OnDeactivation features for the validator of dynamic models.(why not?  it's really intresting)
reason: I found that these two features were not supported because when the validator's activation state changed, if the model was dynamic, it was impossible to determine that it is caused by whether the input result changed or the model changed.so that the 'Valuechanged' could not be automatically cleaned up. So I added an property named FormDefinition to the IModelProperty, through which we can more accurately determine whether the model has changed