### PR TITLE
Change ComboBoxes to use VirtualizingStackPanel to avoid performance …

### DIFF
--- a/Forge.Forms/src/Forge.Forms/Themes/Material/Field.Selection.xaml
+++ b/Forge.Forms/src/Forge.Forms/Themes/Material/Field.Selection.xaml
@@ -44,7 +44,13 @@
                 SelectedValue="{formBuilding:FormBinding Value}"
                 SelectedValuePath="{formBuilding:FormBinding ValuePath}"
                 Style="{StaticResource MaterialDesignFloatingHintComboBox}"
-                ToolTip="{formBuilding:FormBinding ToolTip}" />
+                ToolTip="{formBuilding:FormBinding ToolTip}">
+                <ComboBox.ItemsPanel>
+                    <ItemsPanelTemplate>
+                        <VirtualizingStackPanel />
+                    </ItemsPanelTemplate>
+                </ComboBox.ItemsPanel>
+            </ComboBox>
         </Grid>
     </ControlTemplate>
 
@@ -79,7 +85,13 @@
                 ItemsSource="{formBuilding:FormBinding ItemsSource}"
                 Style="{StaticResource MaterialDesignFloatingHintComboBox}"
                 Text="{formBuilding:FormBinding Value}"
-                ToolTip="{formBuilding:FormBinding ToolTip}" />
+                ToolTip="{formBuilding:FormBinding ToolTip}">
+                <ComboBox.ItemsPanel>
+                    <ItemsPanelTemplate>
+                        <VirtualizingStackPanel />
+                    </ItemsPanelTemplate>
+                </ComboBox.ItemsPanel>
+            </ComboBox>
         </Grid>
     </ControlTemplate>
 

--- a/Forge.Forms/src/Forge.Forms/Themes/Wpf/Field.Selection.xaml
+++ b/Forge.Forms/src/Forge.Forms/Themes/Wpf/Field.Selection.xaml
@@ -49,7 +49,13 @@
                 ItemsSource="{formBuilding:FormBinding ItemsSource}"
                 SelectedValue="{formBuilding:FormBinding Value}"
                 SelectedValuePath="{formBuilding:FormBinding ValuePath}"
-                ToolTip="{formBuilding:FormBinding ToolTip}" />
+                ToolTip="{formBuilding:FormBinding ToolTip}">
+                <ComboBox.ItemsPanel>
+                    <ItemsPanelTemplate>
+                        <VirtualizingStackPanel />
+                    </ItemsPanelTemplate>
+                </ComboBox.ItemsPanel>
+            </ComboBox>
         </Grid>
     </ControlTemplate>
 
@@ -91,7 +97,13 @@
                 ItemStringFormat="{formBuilding:FormBinding ItemStringFormat}"
                 ItemsSource="{formBuilding:FormBinding ItemsSource}"
                 Text="{formBuilding:FormBinding Value}"
-                ToolTip="{formBuilding:FormBinding ToolTip}" />
+                ToolTip="{formBuilding:FormBinding ToolTip}">
+                <ComboBox.ItemsPanel>
+                    <ItemsPanelTemplate>
+                        <VirtualizingStackPanel />
+                    </ItemsPanelTemplate>
+                </ComboBox.ItemsPanel>
+            </ComboBox>
         </Grid>
     </ControlTemplate>
 


### PR DESCRIPTION
…issues with large numbers of options (http://vbcity.com/blogs/xtab/archive/2009/12/15/wpf-using-a-virtualizingstackpanel-to-improve-combobox-performance.aspx)