### PR TITLE
Change MultiBinding syntax

### DIFF
--- a/Forge.Forms/src/Forge.Forms.Demo/Converters/DivideMultiConverter.cs
+++ b/Forge.Forms/src/Forge.Forms.Demo/Converters/DivideMultiConverter.cs
@@ -3,7 +3,7 @@ using System.Globalization;
 using System.Windows;
 using System.Windows.Data;
 
-namespace Forge.Forms.DynamicExpressions.MultiValueConverters
+namespace Forge.Forms.Demo.Converters
 {
     public class DivideMultiConverter : IMultiValueConverter
     {

--- a/Forge.Forms/src/Forge.Forms.Demo/Converters/MultiplyMultiConverter.cs
+++ b/Forge.Forms/src/Forge.Forms.Demo/Converters/MultiplyMultiConverter.cs
@@ -3,7 +3,7 @@ using System.Globalization;
 using System.Windows;
 using System.Windows.Data;
 
-namespace Forge.Forms.DynamicExpressions.MultiValueConverters
+namespace Forge.Forms.Demo.Converters
 {
     public class MultiplyMultiConverter : IMultiValueConverter
     {

--- a/Forge.Forms/src/Forge.Forms.Demo/Forge.Forms.Demo.csproj
+++ b/Forge.Forms/src/Forge.Forms.Demo/Forge.Forms.Demo.csproj
@@ -55,6 +55,8 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Behaviors\CheckAllBehavior.cs" />
+    <Compile Include="Converters\DivideMultiConverter.cs" />
+    <Compile Include="Converters\MultiplyMultiConverter.cs" />
     <Compile Include="Infrastructure\PushBinding.cs" />
     <Compile Include="Infrastructure\TextDocumentValueConverter.cs" />
     <Compile Include="Models\BooleanLogic.cs" />

--- a/Forge.Forms/src/Forge.Forms.Demo/Infrastructure/DemoAppController.cs
+++ b/Forge.Forms/src/Forge.Forms.Demo/Infrastructure/DemoAppController.cs
@@ -2,7 +2,9 @@ using Forge.Application.Infrastructure;
 using Forge.Application.Routing;
 using Forge.Forms.Controls;
 using Forge.Forms.Demo.Behaviors;
+using Forge.Forms.Demo.Converters;
 using Forge.Forms.Demo.Routes;
+using Forge.Forms.DynamicExpressions;
 
 namespace Forge.Forms.Demo.Infrastructure
 {
@@ -10,6 +12,10 @@ namespace Forge.Forms.Demo.Infrastructure
     {
         protected override void OnInitializing()
         {
+            // Add some multiconverters for testing
+            Resource.MultiValueConverters["Divide"] = new DivideMultiConverter();
+            Resource.MultiValueConverters["Multiply"] = new MultiplyMultiConverter();
+
             DynamicForm.AddBehavior(new CheckAllBehavior());
             var factory = Routes.RouteFactory;
            

--- a/Forge.Forms/src/Forge.Forms.Tests/BoundExpressionTests.cs
+++ b/Forge.Forms/src/Forge.Forms.Tests/BoundExpressionTests.cs
@@ -389,6 +389,26 @@ namespace Forge.Forms.Tests
         }
 
         [TestMethod]
+        public void TestMultiConverters()
+        {
+            var context = new DummyFormContext(new DummyForm
+            {
+                Value = new Model
+                {
+                    Value = 5,
+                },
+                Context = new List<int> { 1, 2, 3, 4, 5 }
+            });
+
+            var expression =
+                BoundExpression.Parse(
+                    "{MultiBinding {Binding Value} {Binding Value} |Multiply:0.000}");
+
+            var str = expression.GetStringValue(context).Value;
+            Assert.AreEqual("25.000", str);
+        }
+
+        [TestMethod]
         public void TestApostropheSyntax()
         {
             var expression = BoundExpression.Parse("Hello, {Binding 'FirstName'}");

--- a/Forge.Forms/src/Forge.Forms.Tests/BoundExpressionTests.cs
+++ b/Forge.Forms/src/Forge.Forms.Tests/BoundExpressionTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using System.Windows.Data;
+using Forge.Forms.Demo.Converters;
 using Forge.Forms.DynamicExpressions;
 using Forge.Forms.FormBuilding;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -391,6 +392,10 @@ namespace Forge.Forms.Tests
         [TestMethod]
         public void TestMultiConverters()
         {
+            // Add some multiconverters for testing
+            Resource.MultiValueConverters["Divide"] = new DivideMultiConverter();
+            Resource.MultiValueConverters["Multiply"] = new MultiplyMultiConverter();
+
             var context = new DummyFormContext(new DummyForm
             {
                 Value = new Model

--- a/Forge.Forms/src/Forge.Forms.Tests/Forge.Forms.Tests.csproj
+++ b/Forge.Forms/src/Forge.Forms.Tests/Forge.Forms.Tests.csproj
@@ -58,6 +58,10 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\Forge.Forms.Demo\Forge.Forms.Demo.csproj">
+      <Project>{9366f07d-d5de-4b19-987c-b27c40476685}</Project>
+      <Name>Forge.Forms.Demo</Name>
+    </ProjectReference>
     <ProjectReference Include="..\Forge.Forms\Forge.Forms.csproj">
       <Project>{703572ce-5a7e-4b37-9f12-ff9a11483de2}</Project>
       <Name>Forge.Forms</Name>

--- a/Forge.Forms/src/Forge.Forms/DynamicExpressions/MultiBinding.cs
+++ b/Forge.Forms/src/Forge.Forms/DynamicExpressions/MultiBinding.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using System.Windows.Data;
 using Forge.Forms.FormBuilding;
 
@@ -41,9 +42,20 @@ namespace Forge.Forms.DynamicExpressions
         {
             if (other is MultiBinding resource)
             {
-                return Resources == resource.Resources
-                       && OneTimeBinding == resource.OneTimeBinding
-                       && ValueConverter == resource.ValueConverter;
+                if (Resources.Length == resource.Resources.Length
+                    && OneTimeBinding == resource.OneTimeBinding
+                    && ValueConverter == resource.ValueConverter)
+                {
+                    for (int i = 0; i < Resources.Length; i++)
+                    {
+                        if (Resources[i].Equals(resource.Resources[i]) == false)
+                        {
+                            return false;
+                        }
+                    }
+
+                    return true;
+                }
             }
 
             return false;
@@ -51,7 +63,13 @@ namespace Forge.Forms.DynamicExpressions
 
         public override int GetHashCode()
         {
-            return Resources.GetHashCode() ^ (OneTimeBinding ? 123456789 : 741852963);
+            var hashCode = (OneTimeBinding ? 123456789 : 741852963);
+            foreach (var resource in Resources)
+            {
+                hashCode = resource.GetHashCode() ^ hashCode;
+            }
+
+            return hashCode;
         }
     }
 }

--- a/Forge.Forms/src/Forge.Forms/DynamicExpressions/MultiBinding.cs
+++ b/Forge.Forms/src/Forge.Forms/DynamicExpressions/MultiBinding.cs
@@ -1,23 +1,24 @@
-﻿using System.Windows.Data;
+﻿using System.Collections.Generic;
+using System.Windows.Data;
 using Forge.Forms.FormBuilding;
 
 namespace Forge.Forms.DynamicExpressions
 {
-    public sealed class MultiPropertyBinding : Resource
+    public sealed class MultiBinding : Resource
     {
-        public MultiPropertyBinding(string[] propertyPaths, bool oneTimeBinding)
-            : this(propertyPaths, oneTimeBinding, null)
+        public MultiBinding(Resource[] resources, bool oneTimeBinding)
+            : this(resources, oneTimeBinding, null)
         {
         }
 
-        public MultiPropertyBinding(string[] propertyPaths, bool oneTimeBinding, string valueConverter)
+        public MultiBinding(Resource[] resources, bool oneTimeBinding, string valueConverter)
             : base(valueConverter)
         {
-            PropertyPaths = propertyPaths;
+            Resources = resources;
             OneTimeBinding = oneTimeBinding;
         }
 
-        public string[] PropertyPaths { get; }
+        public Resource[] Resources { get; }
 
         public bool OneTimeBinding { get; }
 
@@ -25,11 +26,11 @@ namespace Forge.Forms.DynamicExpressions
 
         public override BindingBase ProvideBinding(IResourceContext context)
         {
-            var multiBinding = new MultiBinding();
+            var multiBinding = new System.Windows.Data.MultiBinding();
             multiBinding.Converter = GetMultiValueConverter(context);
-            foreach (var propertyPath in PropertyPaths)
+            foreach (var resource in Resources)
             {
-                multiBinding.Bindings.Add(context.CreateModelBinding(propertyPath));
+                multiBinding.Bindings.Add(resource.ProvideBinding(context));
             }
 
             multiBinding.Mode = OneTimeBinding ? BindingMode.OneTime : BindingMode.OneWay;
@@ -38,9 +39,9 @@ namespace Forge.Forms.DynamicExpressions
 
         public override bool Equals(Resource other)
         {
-            if (other is MultiPropertyBinding resource)
+            if (other is MultiBinding resource)
             {
-                return PropertyPaths == resource.PropertyPaths
+                return Resources == resource.Resources
                        && OneTimeBinding == resource.OneTimeBinding
                        && ValueConverter == resource.ValueConverter;
             }
@@ -50,7 +51,7 @@ namespace Forge.Forms.DynamicExpressions
 
         public override int GetHashCode()
         {
-            return PropertyPaths.GetHashCode() ^ (OneTimeBinding ? 123456789 : 741852963);
+            return Resources.GetHashCode() ^ (OneTimeBinding ? 123456789 : 741852963);
         }
     }
 }

--- a/Forge.Forms/src/Forge.Forms/DynamicExpressions/MultiBooleanBinding.cs
+++ b/Forge.Forms/src/Forge.Forms/DynamicExpressions/MultiBooleanBinding.cs
@@ -24,7 +24,7 @@ namespace Forge.Forms.DynamicExpressions
 
         public BindingBase ProvideBinding(IResourceContext context)
         {
-            var multiBinding = new MultiBinding
+            var multiBinding = new System.Windows.Data.MultiBinding
             {
                 Converter = new BooleanMultiConverter(Ast, Resource.GetValueConverter(context, Converter))
             };

--- a/Forge.Forms/src/Forge.Forms/DynamicExpressions/MultiValueBinding.cs
+++ b/Forge.Forms/src/Forge.Forms/DynamicExpressions/MultiValueBinding.cs
@@ -20,7 +20,7 @@ namespace Forge.Forms.DynamicExpressions
 
         public BindingBase ProvideBinding(IResourceContext context)
         {
-            var multiBinding = new MultiBinding
+            var multiBinding = new System.Windows.Data.MultiBinding
             {
                 Converter = Converter
             };

--- a/Forge.Forms/src/Forge.Forms/DynamicExpressions/MultiValueConverters/DivideMultiConverter.cs
+++ b/Forge.Forms/src/Forge.Forms/DynamicExpressions/MultiValueConverters/DivideMultiConverter.cs
@@ -9,79 +9,85 @@ namespace Forge.Forms.DynamicExpressions.MultiValueConverters
     {
         public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
         {
-            if (values.Length == 2 &&
-                values[0] != null &&
-                values[1] != null)
+            try
             {
-                switch (values[0])
+                if (values.Length == 2 &&
+                    values[0] != null &&
+                    values[1] != null)
                 {
-                    case decimal dc1:
-                        switch (values[1])
-                        {
-                            case decimal dc2: return dc1 / dc2;
-                            case double d2: return dc1 / (decimal)d2;
-                            case float f2: return dc1 / (decimal)f2;
-                            case long l2: return dc1 / l2;
-                            case int i2: return dc1 / i2;
-                            case short s2: return dc1 / s2;
-                        }
-                        break;
-                    case double d1:
-                        switch (values[1])
-                        {
-                            case decimal dc2: return (decimal)d1 / dc2;
-                            case double d2: return d1 / d2;
-                            case float f2: return d1 / f2;
-                            case long l2: return d1 / l2;
-                            case int i2: return d1 / i2;
-                            case short s2: return d1 / s2;
-                        }
-                        break;
-                    case float f1:
-                        switch (values[1])
-                        {
-                            case decimal dc2: return (decimal)f1 / dc2;
-                            case double d2: return f1 / d2;
-                            case float f2: return f1 / f2;
-                            case long l2: return f1 / l2;
-                            case int i2: return f1 / i2;
-                            case short s2: return f1 / s2;
-                        }
-                        break;
-                    case long l1:
-                        switch (values[1])
-                        {
-                            case decimal dc2: return l1 / dc2;
-                            case double d2: return l1 / d2;
-                            case float f2: return l1 / f2;
-                            case long l2: return l1 / l2;
-                            case int i2: return l1 / i2;
-                            case short s2: return l1 / s2;
-                        }
-                        break;
-                    case int i1:
-                        switch (values[1])
-                        {
-                            case decimal dc2: return i1 / dc2;
-                            case double d2: return i1 / d2;
-                            case float f2: return i1 / f2;
-                            case long l2: return i1 / l2;
-                            case int i2: return i1 / i2;
-                            case short s2: return i1 / s2;
-                        }
-                        break;
-                    case short s1:
-                        switch (values[1])
-                        {
-                            case decimal dc2: return s1 / dc2;
-                            case double d2: return s1 / d2;
-                            case float f2: return s1 / f2;
-                            case long l2: return s1 / l2;
-                            case int i2: return s1 / i2;
-                            case short s2: return s1 / s2;
-                        }
-                        break;
+                    switch (values[0])
+                    {
+                        case decimal dc1:
+                            switch (values[1])
+                            {
+                                case decimal dc2: return dc1 / dc2;
+                                case double d2: return dc1 / (decimal)d2;
+                                case float f2: return dc1 / (decimal)f2;
+                                case long l2: return dc1 / l2;
+                                case int i2: return dc1 / i2;
+                                case short s2: return dc1 / s2;
+                            }
+                            break;
+                        case double d1:
+                            switch (values[1])
+                            {
+                                case decimal dc2: return (decimal)d1 / dc2;
+                                case double d2: return d1 / d2;
+                                case float f2: return d1 / f2;
+                                case long l2: return d1 / l2;
+                                case int i2: return d1 / i2;
+                                case short s2: return d1 / s2;
+                            }
+                            break;
+                        case float f1:
+                            switch (values[1])
+                            {
+                                case decimal dc2: return (decimal)f1 / dc2;
+                                case double d2: return f1 / d2;
+                                case float f2: return f1 / f2;
+                                case long l2: return f1 / l2;
+                                case int i2: return f1 / i2;
+                                case short s2: return f1 / s2;
+                            }
+                            break;
+                        case long l1:
+                            switch (values[1])
+                            {
+                                case decimal dc2: return l1 / dc2;
+                                case double d2: return l1 / d2;
+                                case float f2: return l1 / f2;
+                                case long l2: return l1 / l2;
+                                case int i2: return l1 / i2;
+                                case short s2: return l1 / s2;
+                            }
+                            break;
+                        case int i1:
+                            switch (values[1])
+                            {
+                                case decimal dc2: return i1 / dc2;
+                                case double d2: return i1 / d2;
+                                case float f2: return i1 / f2;
+                                case long l2: return i1 / l2;
+                                case int i2: return i1 / i2;
+                                case short s2: return i1 / s2;
+                            }
+                            break;
+                        case short s1:
+                            switch (values[1])
+                            {
+                                case decimal dc2: return s1 / dc2;
+                                case double d2: return s1 / d2;
+                                case float f2: return s1 / f2;
+                                case long l2: return s1 / l2;
+                                case int i2: return s1 / i2;
+                                case short s2: return s1 / s2;
+                            }
+                            break;
+                    }
                 }
+            }
+            catch (DivideByZeroException)
+            {
             }
 
             return DependencyProperty.UnsetValue;

--- a/Forge.Forms/src/Forge.Forms/DynamicExpressions/Resource.cs
+++ b/Forge.Forms/src/Forge.Forms/DynamicExpressions/Resource.cs
@@ -4,7 +4,6 @@ using System.Globalization;
 using System.Text;
 using System.Windows;
 using System.Windows.Data;
-using Forge.Forms.DynamicExpressions.MultiValueConverters;
 using Forge.Forms.DynamicExpressions.ValueConverters;
 using Forge.Forms.FormBuilding;
 
@@ -44,8 +43,6 @@ namespace Forge.Forms.DynamicExpressions
         public static readonly Dictionary<string, IMultiValueConverter> MultiValueConverters =
             new Dictionary<string, IMultiValueConverter>(StringComparer.OrdinalIgnoreCase)
             {
-                ["Divide"] = new DivideMultiConverter(),
-                ["Multiply"] = new MultiplyMultiConverter(),
             };
 
         public static readonly Dictionary<string, Func<object, IMultiValueConverter>> MultiValueConverterFactories =

--- a/Forge.Forms/src/Forge.Forms/Forge.Forms.csproj
+++ b/Forge.Forms/src/Forge.Forms/Forge.Forms.csproj
@@ -117,8 +117,6 @@
     <Compile Include="DynamicExpressions\MultiValueBinding.cs" />
     <Compile Include="DynamicExpressions\InvariantDouble.cs" />
     <Compile Include="DynamicExpressions\InvariantInt.cs" />
-    <Compile Include="DynamicExpressions\MultiValueConverters\DivideMultiConverter.cs" />
-    <Compile Include="DynamicExpressions\MultiValueConverters\MultiplyMultiConverter.cs" />
     <Compile Include="DynamicExpressions\ValueConverters\IsEqualConverter.cs" />
     <Compile Include="FormBuilding\Defaults\DirectContentField.cs" />
     <Compile Include="FormBuilding\Defaults\Properties\DirectContentBuilder.cs" />
@@ -424,5 +422,6 @@
       <Generator>XamlIntelliSenseFileGenerator</Generator>
     </Page>
   </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/Forge.Forms/src/Forge.Forms/Forge.Forms.csproj
+++ b/Forge.Forms/src/Forge.Forms/Forge.Forms.csproj
@@ -112,8 +112,8 @@
     <Compile Include="DynamicExpressions\EnvironmentBinding.cs" />
     <Compile Include="DynamicExpressions\FileBinding.cs" />
     <Compile Include="DynamicExpressions\FileWatcher.cs" />
+    <Compile Include="DynamicExpressions\MultiBinding.cs" />
     <Compile Include="DynamicExpressions\MultiBooleanBinding.cs" />
-    <Compile Include="DynamicExpressions\MultiPropertyBinding.cs" />
     <Compile Include="DynamicExpressions\MultiValueBinding.cs" />
     <Compile Include="DynamicExpressions\InvariantDouble.cs" />
     <Compile Include="DynamicExpressions\InvariantInt.cs" />


### PR DESCRIPTION
Change MultiBinding syntax to: "{MultiBinding {Binding Value1} {Binding Value2} |MultiConverter:StringFormat}" to support any resource type being used by a MultiBinding converter.